### PR TITLE
fix(release): bind production environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- bind the Release workflow to the `production` environment to satisfy npm trusted publishing

## Testing
- not run (CI will run)

Refs #8