### PR TITLE
chore(release): add repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jbatte47/lattice"
+  },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",


### PR DESCRIPTION
## Summary
- add repository metadata required for npm provenance checks

## Testing
- not run (metadata-only change)

Fixes #66