### PR TITLE
feat(process): require conventional PR titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ PR descriptions must follow this format and include the issue link that will be 
 Fixes #<issue-number>
 ```
 
+### Pull Request Title
+
+PR titles must use Conventional Commit format. When we squash merge, the PR title becomes the commit subject, which drives semantic-release.
+
+- **Pattern**: `<type>(<scope>): <description>`
+- **Example**: `feat(tokens): generate tokens.css at build time`
+
 ### Tooling (Lint + Format)
 
 Lattice uses `pnpm` and a repo-wide ESLint + Prettier setup.


### PR DESCRIPTION
## Summary
- document conventional PR title format used for squash merges
- clarify semantic-release relies on the PR title commit subject

## Testing
- not run (docs-only change)

Fixes #72
