### PR TITLE
fix(ci): generate tokens before typecheck

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Format
         run: pnpm format
 
+      - name: Generate tokens
+        run: node scripts/build-semantic-tokens.mjs
+
       - name: Typecheck
         run: pnpm typecheck
 


### PR DESCRIPTION
## Summary
- run semantic token generator before release typecheck to ensure artifacts exist

## Testing
- not run (CI only)

Fixes #75